### PR TITLE
refactor: relocate BeanResultCleanup from the core of Smooks to this …

### DIFF
--- a/cartridge/src/main/java/org/smooks/cartridges/javabean/lifecycle/BeanResultCleanup.java
+++ b/cartridge/src/main/java/org/smooks/cartridges/javabean/lifecycle/BeanResultCleanup.java
@@ -1,0 +1,98 @@
+/*-
+ * ========================LICENSE_START=================================
+ * smooks-javabean-cartridge
+ * %%
+ * Copyright (C) 2020 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.cartridges.javabean.lifecycle;
+
+import org.smooks.container.ExecutionContext;
+import org.smooks.delivery.sax.ng.BeforeVisitor;
+import org.smooks.delivery.sax.ng.SaxNgVisitor;
+import org.smooks.javabean.context.BeanContext;
+import org.smooks.lifecycle.ExecutionLifecycleCleanable;
+import org.smooks.util.CollectionsUtil;
+import org.w3c.dom.Element;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * Bean Result Cleanup resource.
+ * <p/>
+ * Execution Lifecycle Cleanable resource that performs Java result cleaup.
+ *
+ * @author <a href="mailto:tom.fennelly@jboss.com">tom.fennelly@jboss.com</a>
+ */
+public class BeanResultCleanup implements ExecutionLifecycleCleanable, BeforeVisitor {
+
+    @Inject
+    private String[] beanIDs;
+    private Set<String> beanIDSet;
+
+    @PostConstruct
+    public void postConstruct() {
+        beanIDSet = CollectionsUtil.toSet(beanIDs);
+    }
+
+    /**
+     * Execute the cleanup.
+     *
+     * @param executionContext The execution context.
+     */
+    @Override
+    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+        BeanContext beanContext = executionContext.getBeanContext();
+        Set<Entry<String, Object>> beanSet = beanContext.getBeanMap().entrySet();
+
+        for (Entry<String, Object> beanEntry : beanSet) {
+            String beanID = beanEntry.getKey();
+            if (!beanIDSet.contains(beanID)) {
+                beanContext.removeBean(beanID, null);
+            }
+        }
+    }
+
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) {
+        
+    }
+}

--- a/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd-smooks.xml
+++ b/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd-smooks.xml
@@ -321,7 +321,7 @@
 
     <resource-config selector="jb:result">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
-        <param name="resource">org.smooks.javabean.lifecycle.BeanResultCleanup</param>
+        <param name="resource">org.smooks.cartridges.javabean.lifecycle.BeanResultCleanup</param>
     </resource-config>
 
     <resource-config selector="jb:result">


### PR DESCRIPTION
…cartridge given that it's not referenced from anywhere else