### PR TITLE
chore!: update to latest snapshot of Smooks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -208,7 +208,6 @@ This configuration simply creates an instance of the `+example.model.Order+` cla
 * `+beanId+`: The id of this bean. Please see link:#the-bean-context[The Bean Context] for more details.
 * `+class+`: The fully qualified class name of the bean.
 * `+createOnElement+`: attribute controls when the bean instance is created. Population of the bean properties is controlled through the binding configurations (child elements of the element).
-* `+createOnElementNS+`: The namespace of the createOnElement can be specified via the `+createOnElementNS+` attribute.
 
 The Javabean cartridge has the following conditions for javabeans:
 

--- a/cartridge/src/main/java/org/smooks/cartridges/javabean/Bean.java
+++ b/cartridge/src/main/java/org/smooks/cartridges/javabean/Bean.java
@@ -156,7 +156,6 @@ public class Bean extends BindingAppender {
     private final BeanInstanceCreator beanInstanceCreator;
     private final Class<?> beanClass;
     private final String createOnElement;
-    private final String targetNamespace;
     private final List<Binding> bindings = new ArrayList<>();
     private final List<Bean> wirings = new ArrayList<>();
 
@@ -185,30 +184,18 @@ public class Bean extends BindingAppender {
      * @param factory		   The factory that will create the runtime object
      */
     public <T> Bean(Class<T> beanClass, String beanId, Factory<? extends T> factory, Registry registry) {
-    	this(beanClass, beanId, ResourceConfig.DOCUMENT_FRAGMENT_SELECTOR, null, factory, registry);
+    	this(beanClass, beanId, ResourceConfig.DOCUMENT_FRAGMENT_SELECTOR, factory, registry);
     }
 
     /**
      * Create a Bean binding configuration.
      *
-     * @param beanClass        The bean runtime class.
-     * @param beanId           The bean ID.
-     * @param createOnElement  The element selector used to create the bean instance.
+     * @param beanClass         The bean runtime class.
+     * @param beanId            The bean ID.
+     * @param createOnElement   The element selector used to create the bean instance.
      */
     public Bean(Class<?> beanClass, String beanId, String createOnElement, Registry registry) {
-        this(beanClass, beanId, createOnElement, (String)null, registry);
-    }
-
-    /**
-     * Create a Bean binding configuration.
-     *
-     * @param beanClass        The bean runtime class.
-     * @param beanId           The bean ID.
-     * @param createOnElement  The element selector used to create the bean instance.
-     * @param factory		   The factory that will create the runtime object
-     */
-    public <T> Bean(Class<T> beanClass, String beanId, String createOnElement, Factory<? extends T> factory, Registry registry) {
-        this(beanClass, beanId, createOnElement, (String)null, factory, registry);
+        this(beanClass, beanId, createOnElement, null, registry);
     }
 
     /**
@@ -217,22 +204,9 @@ public class Bean extends BindingAppender {
      * @param beanClass         The bean runtime class.
      * @param beanId            The bean ID.
      * @param createOnElement   The element selector used to create the bean instance.
-     * @param createOnElementNS The namespace for the element selector used to create the bean instance.
-     */
-    public Bean(Class<?> beanClass, String beanId, String createOnElement, String createOnElementNS, Registry registry) {
-        this(beanClass, beanId, createOnElement, createOnElementNS, null, registry);
-    }
-
-    /**
-     * Create a Bean binding configuration.
-     *
-     * @param beanClass         The bean runtime class.
-     * @param beanId            The bean ID.
-     * @param createOnElement   The element selector used to create the bean instance.
-     * @param createOnElementNS The namespace for the element selector used to create the bean instance.
      * @param factory		   	The factory that will create the runtime object
      */
-    public <T> Bean(Class<T> beanClass, String beanId, String createOnElement, String createOnElementNS, Factory<? extends T> factory, Registry registry) {
+    public <T> Bean(Class<T> beanClass, String beanId, String createOnElement, Factory<? extends T> factory, Registry registry) {
     	super(beanId);
         AssertArgument.isNotNull(beanClass, "beanClass");
         AssertArgument.isNotNull(createOnElement, "createOnElement");
@@ -247,7 +221,6 @@ public class Bean extends BindingAppender {
 
         this.beanClass = beanClass;
         this.createOnElement = createOnElement;
-        this.targetNamespace = createOnElementNS;
         this.registry = registry;
         beanInstanceCreator = new BeanInstanceCreator(beanId, beanClass, factory);
     }
@@ -258,10 +231,9 @@ public class Bean extends BindingAppender {
      * @param beanClass         The bean runtime class.
      * @param beanId            The bean ID.
      * @param createOnElement   The element selector used to create the bean instance.
-     * @param createOnElementNS The namespace for the element selector used to create the bean instance.
      */
-    public static Bean newBean(Class<?> beanClass, String beanId, String createOnElement, String createOnElementNS, Registry registry) {
-        return new Bean(beanClass, beanId, createOnElement, createOnElementNS, registry);
+    public static Bean newBean(Class<?> beanClass, String beanId, String createOnElement, Registry registry) {
+        return new Bean(beanClass, beanId, createOnElement, registry);
     }
 
 
@@ -271,11 +243,10 @@ public class Bean extends BindingAppender {
      * @param beanClass         The bean runtime class.
      * @param beanId            The bean ID.
      * @param createOnElement   The element selector used to create the bean instance.
-     * @param createOnElementNS The namespace for the element selector used to create the bean instance.
      * @param factory		    The factory that will create the runtime object
      */
-    public static <T> Bean  newBean(Class<T> beanClass, String beanId, String createOnElement, String createOnElementNS, Factory<T> factory, Registry registry) {
-        return new Bean(beanClass, beanId, createOnElement, createOnElementNS, factory, registry);
+    public static <T> Bean  newBean(Class<T> beanClass, String beanId, String createOnElement, Factory<T> factory, Registry registry) {
+        return new Bean(beanClass, beanId, createOnElement, factory, registry);
     }
 
     /**
@@ -537,7 +508,7 @@ public class Bean extends BindingAppender {
 
         List<ContentHandlerBinding<Visitor>> visitorBindings = new ArrayList<>();
         // Add the create bean visitor...
-        ContentHandlerBinding<Visitor> beanInstanceCreateBinding = new DefaultContentHandlerBinding<>(beanInstanceCreator, createOnElement, targetNamespace, registry);
+        ContentHandlerBinding<Visitor> beanInstanceCreateBinding = new DefaultContentHandlerBinding<>(beanInstanceCreator, createOnElement, registry);
         ResourceConfig beanInstanceCreatorSmooksResourceConfiguration = beanInstanceCreateBinding.getResourceConfig();
         beanInstanceCreatorSmooksResourceConfiguration.setParameter("beanId", getBeanId());
         beanInstanceCreatorSmooksResourceConfiguration.setParameter("beanClass", beanClass.getName());
@@ -551,7 +522,7 @@ public class Bean extends BindingAppender {
 
         // Add the populate bean visitors...
         for(Binding binding : bindings) {
-            ContentHandlerBinding<Visitor> beanInstancePopulatorBinding = new DefaultContentHandlerBinding<>(binding.beanInstancePopulator, binding.selector, targetNamespace, registry);
+            ContentHandlerBinding<Visitor> beanInstancePopulatorBinding = new DefaultContentHandlerBinding<>(binding.beanInstancePopulator, binding.selector, registry);
             beanInstancePopulatorBinding.getResourceConfig().setParameter("beanId", getBeanId());
             visitorBindings.add(beanInstancePopulatorBinding);
             if(binding.assertTargetIsCollection) {

--- a/cartridge/src/main/java/org/smooks/cartridges/javabean/Value.java
+++ b/cartridge/src/main/java/org/smooks/cartridges/javabean/Value.java
@@ -224,7 +224,7 @@ public class Value extends BindingAppender {
 		valueBinder.setDefaultValue(defaultValue);
 		valueBinder.setValueAttributeName(valueBinderSmooksResourceConfiguration.getParameterValue(BeanInstancePopulator.VALUE_ATTRIBUTE_NAME, String.class));
 
-		visitorBindings.add(new DefaultContentHandlerBinding<>(valueBinder, valueBinderSmooksResourceConfiguration.getSelectorPath().getSelector(), targetNamespace, registry));
+		visitorBindings.add(new DefaultContentHandlerBinding<>(valueBinder, valueBinderSmooksResourceConfiguration.getSelectorPath().getSelector(), registry));
 	
 		return visitorBindings;
 	}

--- a/cartridge/src/main/java/org/smooks/cartridges/javabean/dynamic/ext/BeanWriterFactory.java
+++ b/cartridge/src/main/java/org/smooks/cartridges/javabean/dynamic/ext/BeanWriterFactory.java
@@ -85,7 +85,10 @@ public class BeanWriterFactory implements ContentHandler {
         try {
             BeanWriter beanWriter = beanWriterClass.newInstance();
             appContext.getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(beanWriter, new PostConstructLifecyclePhase(new Scope(appContext.getRegistry(), resourceConfig, beanWriter)));
-            getBeanWriters(beanClass, appContext).put(resourceConfig.getSelectorPath().getSelectorNamespaceURI(), beanWriter);
+            Map<String, BeanWriter> beanWriters = getBeanWriters(beanClass, appContext);
+            for (Object namespaceUri : resourceConfig.getSelectorPath().getNamespaces().values()) {
+                beanWriters.put((String) namespaceUri, beanWriter);
+            }
         } catch (InstantiationException | IllegalAccessException e) {
             throw new SmooksConfigException("Unable to create BeanWriter instance.", e);
         }

--- a/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd
+++ b/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd
@@ -18,7 +18,7 @@
                 created (and bound) when the element event
                 specified in the "createOnElement" attribute
                 is encountered in the Source data event
-                stream (see also "createOnElementNS").
+                stream.
                 <h3>Bean Property/Member Population</h3>
                 Bean property/member population is
                 controlled by the binding sub-elements
@@ -122,18 +122,10 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="createOnElementNS" type="xs:anyURI">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
-                            Namespace control for the
-                            "createOnElement" attribute.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
                 <xs:attribute name="retain" type="xs:boolean">
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
-                            Retain the bean in Smooks BenaContext after the creating
+                            Retain the bean in Smooks BeanContext after the creating
                             fragment has been processed.
                             <p/>
                             Default the value is 'false'.

--- a/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd-smooks.xml
+++ b/cartridge/src/main/resources/META-INF/xsd/smooks/javabean-1.6.xsd-smooks.xml
@@ -65,18 +65,6 @@
         -->
         <param name="defaultValue">none</param>
     </resource-config>
-    
-    <resource-config selector="jb:bean">
-        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">createOnElementNS</param>
-        <param name="mapTo">namespaceURI</param>
-
-        <!--
-        	If not set then the $void selector is used to make sure that the  BeanInstanceCreator gets
-            initialized but never executed on an element.
-        -->
-        <param name="defaultValue">none</param>
-    </resource-config>
 
     <resource-config selector="jb:bean">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
-        <smooks.version>2.0.0-RC3</smooks.version>
+        <smooks.version>2.0.0-SNAPSHOT</smooks.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
BREAKING CHANGE: dropped XML attribute `createOnElementNS` since it makes use of the deprecated selector-namespace attribute. This functionality can be easily replaced by inserting the namespace prefix in the selector